### PR TITLE
ECM-17: Added the technical possibility to run BDD Tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,13 @@
 language: java
 jdk:
-- oraclejdk8
+  - oraclejdk8
+before_install:
+  - chmod +x *.sh
+before_script:
+  - source ./start-xvfb.sh
+script: 
+# Maven have to be called manually, because travis is starting maven only to the test phase. So the integration tests can't be started.
+  - ./mvnw verify
 deploy:
   edge: true
   provider: cloudfoundry
@@ -10,3 +17,7 @@ deploy:
   api: https://api.run.pivotal.io
   organization: tosch
   space: development
+  on:
+    repo: EduCaMa/Showcase
+addons:
+  firefox: "42.0"

--- a/pom.xml
+++ b/pom.xml
@@ -21,10 +21,10 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>1.8</java.version>
-		<serenity.version>1.0.47</serenity.version>
-		<serenity.maven.version>1.0.47</serenity.maven.version>
+		<serenity.version>1.1.36</serenity.version>
+		<serenity.maven.version>1.1.36</serenity.maven.version>
 		<webdriver.driver>firefox</webdriver.driver>
-		<serenity.jbehave.version>1.0.21</serenity.jbehave.version>
+		<serenity.jbehave.version>1.6.0</serenity.jbehave.version>
 	</properties>
 
 	<dependencies>
@@ -46,7 +46,7 @@
 
 		<dependency>
 			<groupId>net.serenity-bdd</groupId>
-			<artifactId>core</artifactId>
+			<artifactId>serenity-core</artifactId>
 			<version>${serenity.version}</version>
 		</dependency>
 		<dependency>
@@ -140,7 +140,7 @@
 				<dependencies>
 					<dependency>
 						<groupId>net.serenity-bdd</groupId>
-						<artifactId>core</artifactId>
+						<artifactId>serenity-core</artifactId>
 						<version>${serenity.version}</version>
 					</dependency>
 				</dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 		<dependency>
 			<groupId>org.camunda.bpm.extension</groupId>
 			<artifactId>camunda-bpm-spring-boot-starter-webapp</artifactId>
-			<version>1.2.1</version>
+			<version>1.3.0</version>
 		</dependency>
 		<dependency>
 			<groupId>com.h2database</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -154,14 +154,7 @@
 					</execution>
 				</executions>
 			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-surefire-plugin</artifactId>
-				<configuration>
-					<testFailureIgnore>true</testFailureIgnore>
-				</configuration>
-			</plugin>
 		</plugins>
 	</build>
-
+	
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -50,10 +50,10 @@
 			<version>${serenity.version}</version>
 		</dependency>
 		<dependency>
-            <groupId>net.serenity-bdd</groupId>
-            <artifactId>serenity-jbehave</artifactId>
-            <version>${serenity.jbehave.version}</version>
-        </dependency>
+			<groupId>net.serenity-bdd</groupId>
+			<artifactId>serenity-jbehave</artifactId>
+			<version>${serenity.jbehave.version}</version>
+		</dependency>
 		<dependency>
 			<groupId>net.serenity-bdd</groupId>
 			<artifactId>serenity-junit</artifactId>
@@ -81,6 +81,27 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>pre-integration-test</id>
+						<goals>
+							<goal>start</goal>
+						</goals>
+						<configuration>
+							<wait>5000</wait>
+							<maxAttempts>15</maxAttempts>
+							<arguments>
+								<argument>--server.port=8081</argument>
+							</arguments>
+						</configuration>
+					</execution>
+					<execution>
+						<id>post-integration-test</id>
+						<goals>
+							<goal>stop</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
 			<!-- Plugin to create releases: Use ./mvnw release:clean release:prepare 
 				-DpushChanges=false to create a release. -->
@@ -154,7 +175,33 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<configuration>
+					<excludes>
+						<exclude>**/*AcceptanceTests.java</exclude>
+					</excludes>
+				</configuration>
+				<executions>
+					<execution>
+						<id>integration-test</id>
+						<goals>
+							<goal>test</goal>
+						</goals>
+						<phase>integration-test</phase>
+						<configuration>
+							<testFailureIgnore>true</testFailureIgnore>
+							<excludes>
+								<exclude>none</exclude>
+							</excludes>
+							<includes>
+								<include>**/*AcceptanceTests.java</include>
+							</includes>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
-	
 </project>

--- a/src/main/resources/serenity.properties
+++ b/src/main/resources/serenity.properties
@@ -1,0 +1,2 @@
+serenity.use.unique.browser=true
+serenity.take.screenshots=AFTER_EACH_STEP

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -9,8 +9,8 @@
         <h1>Welcome to EduCaMa</h1>
         <div>
           <label>Name:</label>
-          <input type="text" ng-model="yourName" placeholder="Enter a name here">
-          <h1>Hello {{yourName}}!</h1>
+          <input id="nameInputBox" type="text" ng-model="yourName" placeholder="Enter a name here">
+          <h1 id="greetingsHeading">Hello {{yourName}}!</h1>
         </div>
         <hr>
         <ul>

--- a/src/test/java/educama/EducamaApplicationTests.java
+++ b/src/test/java/educama/EducamaApplicationTests.java
@@ -7,12 +7,20 @@ import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 
+/**
+ * This test is the integration test for the spring boot implementation.
+ * 
+ *
+ */
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringApplicationConfiguration(classes = EducamaApplication.class)
 @WebAppConfiguration
 @IntegrationTest
 public class EducamaApplicationTests {
 
+	/**
+	 * this test actually tests that the Spring Context is created successfully, i.e. the application starts successfully.
+	 */
 	@Test
 	public void contextLoads() {
 	}

--- a/src/test/java/educama/EducamaApplicationTests.java
+++ b/src/test/java/educama/EducamaApplicationTests.java
@@ -7,8 +7,6 @@ import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 
-import educama.EducamaApplication;
-
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringApplicationConfiguration(classes = EducamaApplication.class)
 @WebAppConfiguration

--- a/src/test/java/educama/acceptancetests/pages/WelcomePage.java
+++ b/src/test/java/educama/acceptancetests/pages/WelcomePage.java
@@ -1,0 +1,25 @@
+package educama.acceptancetests.pages;
+
+import org.openqa.selenium.WebElement;
+
+import net.serenitybdd.core.annotations.findby.FindBy;
+import net.serenitybdd.core.pages.PageObject;
+import net.thucydides.core.annotations.DefaultUrl;
+
+@DefaultUrl("http://localhost:8081")
+public class WelcomePage extends PageObject {
+
+	@FindBy(id = "nameInputBox")
+	WebElement inputName;
+	
+	@FindBy(id = "greetingsHeading")
+	WebElement headingGreetings;
+	
+	public void enterNameInInputbox(String name) {
+		inputName.sendKeys(name);
+	}
+
+	public String getGreetings() {
+		return headingGreetings.getText();
+	}
+}

--- a/src/test/java/educama/acceptancetests/stepdefinitions/CaseStepDefinitions.java
+++ b/src/test/java/educama/acceptancetests/stepdefinitions/CaseStepDefinitions.java
@@ -1,0 +1,35 @@
+package educama.acceptancetests.stepdefinitions;
+
+import org.jbehave.core.annotations.Given;
+import org.jbehave.core.annotations.Named;
+import org.jbehave.core.annotations.Then;
+import org.jbehave.core.annotations.When;
+
+import educama.acceptancetests.steps.CaseSteps;
+import net.thucydides.core.annotations.Steps;
+
+public class CaseStepDefinitions extends GlobalStepDefinitions {
+
+	@Steps
+	CaseSteps user;
+	
+	/*
+	 * Show-cases.story
+	 */
+
+	@Given("the main page is shown")
+	public void givenTheMainPageIsShown() {
+		user.opensThePage();
+	}
+
+	@When("I enter the name $name")
+	public void whenIEnterTheName(@Named("name") String name) {
+		user.entersTheName(name);
+	}
+
+	@Then("$name should be greeted")
+	public void thenNameShouldBeGreeted(@Named("name") String name) {
+		user.checksHeading(name);
+	}
+
+}

--- a/src/test/java/educama/acceptancetests/stepdefinitions/GlobalStepDefinitions.java
+++ b/src/test/java/educama/acceptancetests/stepdefinitions/GlobalStepDefinitions.java
@@ -1,0 +1,5 @@
+package educama.acceptancetests.stepdefinitions;
+
+public class GlobalStepDefinitions {
+
+}

--- a/src/test/java/educama/acceptancetests/steps/CaseSteps.java
+++ b/src/test/java/educama/acceptancetests/steps/CaseSteps.java
@@ -1,0 +1,27 @@
+package educama.acceptancetests.steps;
+
+import static org.junit.Assert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+
+import educama.acceptancetests.pages.WelcomePage;
+import net.thucydides.core.annotations.Step;
+
+public class CaseSteps {
+
+	WelcomePage welcomePage;
+	
+	@Step
+	public void opensThePage() {
+		welcomePage.open();
+	}
+
+	@Step
+	public void entersTheName(String name) {
+		welcomePage.enterNameInInputbox(name);
+	}
+
+	@Step
+	public void checksHeading(String name) {
+		assertThat("The greetings are wrong", welcomePage.getGreetings().contains(name), is(true));
+	}
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,2 +1,3 @@
 # Change port so that tests can execute while application is running
 server.port=8081
+camunda.bpm.webapp.index-redirect-enabled=false

--- a/src/test/resources/stories/managementOfCases/show/show-cases.story
+++ b/src/test/resources/stories/managementOfCases/show/show-cases.story
@@ -13,3 +13,8 @@ Scenario: List open cases with 1 case
 Given There is 1 case
 When I show the list of open cases
 Then I see 1 case
+
+Scenario: Show entered name
+Given the main page is shown
+When I enter the name John Doe
+Then John Doe should be greeted

--- a/start-xvfb.sh
+++ b/start-xvfb.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Integration of X.org for starting firefox with serenity:
+# https://docs.travis-ci.com/user/gui-and-headless-browsers/#Using-xvfb-to-Run-Tests-That-Require-a-GUI
+set -e # Exit with nonzero exit code if anything fails
+
+export DISPLAY=:99.0
+sh -e /etc/init.d/xvfb start
+sleep 3 # give xvfb some time to start


### PR DESCRIPTION
- Removed the test will not fail flag from pom
- Added the example BDD Test with serenity
- Added in .travis.yml the configuration for starting X.org. It is needed for the serenity tests
- Added in .travis.yml the script flag, because travis build maven only to the test phase. All integration tests will not be executed.
- Added in .travis.yml a condition that the deployment will only be done if the repository name is "EduCaMa/Showcase"