### PR TITLE
ECM-45: Create Camunda-demo-user in backend

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -7,3 +7,8 @@ hs_err_pid*
 .classpath
 .project
 /manifest.yml
+
+# IntelliJ
+.idea
+.mvn
+*.iml

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -29,6 +29,10 @@
 			<version>1.3.0</version>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-jpa</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
 		</dependency>

--- a/backend/src/main/java/org/educama/EducamaApplication.java
+++ b/backend/src/main/java/org/educama/EducamaApplication.java
@@ -2,9 +2,16 @@ package org.educama;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.camunda.bpm.spring.boot.starter.SpringBootProcessApplication;
 
+/*
+ * Note that extending SpringBootProcessApplication may cause that some Camunda-auto-detect-features won't work.
+ * For example define a process.xml will be necessary in some cases.
+ * In general working with camunda-bpm-spring-boot-starter-webapp will be more according to Camunda documentation
+ * instead of camunda-bpm-spring-boot-starter-webapp documentation.
+ */
 @SpringBootApplication
-public class EducamaApplication {
+public class EducamaApplication extends SpringBootProcessApplication {
 
 	public static void main(String[] args) {
 		SpringApplication.run(EducamaApplication.class, args);

--- a/backend/src/main/java/org/educama/configuration/CamundaConfiguration.java
+++ b/backend/src/main/java/org/educama/configuration/CamundaConfiguration.java
@@ -1,0 +1,76 @@
+package org.educama.configuration;
+
+import org.camunda.bpm.engine.ProcessEngine;
+import org.camunda.bpm.engine.authorization.Authorization;
+
+import org.camunda.bpm.engine.authorization.Resources;
+import org.camunda.bpm.engine.filter.Filter;
+import org.camunda.bpm.engine.identity.Group;
+import org.camunda.bpm.engine.identity.User;
+import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.camunda.bpm.engine.impl.cfg.ProcessEnginePlugin;
+import org.camunda.bpm.engine.task.TaskQuery;
+import org.camunda.bpm.spring.boot.starter.configuration.Ordering;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+
+@Configuration
+@Order(Ordering.DEFAULT_ORDER + 1)
+public class CamundaConfiguration implements ProcessEnginePlugin {
+	
+	/*
+	 * The values of the cofiguration-variables are defined in Spring-Properties.
+	 * For example: src/main/resources/application.properties.
+	 * 
+	 * All of the configurations below should be checked again the needs of a production environment.
+	 * During developing-stage this configuration will be helpful.
+	 */
+	
+	@Value("${org.educama.configuration.adminUser}")
+	private String adminUsername;
+	
+	@Value("${org.educama.configuration.adminPassword}")
+	private String adminPassword;
+	
+	@Override
+	public void preInit(ProcessEngineConfigurationImpl processEngineConfiguration) {
+		
+	}
+
+	@Override
+	public void postInit(ProcessEngineConfigurationImpl processEngineConfiguration) {
+		
+	}
+
+	@Override
+	public void postProcessEngineBuild(ProcessEngine processEngine) {
+		
+		// create user based on properties given through spring
+		User user = processEngine.getIdentityService().newUser(adminUsername);
+			user.setPassword(adminPassword);
+			user.setFirstName("EduCaMa");
+			user.setLastName("User");		
+		processEngine.getIdentityService().saveUser(user);
+		
+		// create a admin group and put the new user into it
+		Group adminGroup = processEngine.getIdentityService().newGroup("camunda-admin"); 
+		processEngine.getIdentityService().saveGroup(adminGroup);
+		processEngine.getIdentityService().createMembership(user.getId(), adminGroup.getId());
+		
+		// authorize the group with type 'grant' to resource 'user' and enable 'all' permissions
+		Authorization authorization = processEngine.getAuthorizationService()
+				.createNewAuthorization(Authorization.AUTH_TYPE_GRANT);
+			authorization.setGroupId(adminGroup.getId());
+			authorization.setResource(Resources.USER);
+			authorization.addPermission(org.camunda.bpm.engine.authorization.Permissions.ALL);
+		processEngine.getAuthorizationService().saveAuthorization(authorization);
+		
+		// define a default query which shows all assigned tasks
+		TaskQuery query = processEngine.getTaskService().createTaskQuery().taskAssignee(adminUsername);
+		Filter taskFilter = processEngine.getFilterService().newTaskFilter("assigned Tasks");
+			taskFilter.setOwner(adminUsername);
+			taskFilter.setQuery(query);
+		processEngine.getFilterService().saveFilter(taskFilter);
+	}
+}

--- a/backend/src/main/java/org/educama/shipment/api/ShipmentController.java
+++ b/backend/src/main/java/org/educama/shipment/api/ShipmentController.java
@@ -1,0 +1,45 @@
+/*
+ * *************************************************************************
+ *
+ * Copyright:       Robert Bosch GmbH, 2016
+ *
+ * *************************************************************************
+ */
+
+/**
+ * Dear "developer", please document your class RIGHT HERE!.
+ */
+
+package org.educama.shipment.api;
+
+import org.educama.shipment.api.resource.ShipmentListResource;
+import org.educama.shipment.api.resource.ShipmentResource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(path = ShipmentController.SHIPMENT_RESOURCE_PATH, produces = {MediaType.APPLICATION_JSON_UTF8_VALUE})
+public class ShipmentController {
+
+    public static final String SHIPMENT_RESOURCE_PATH = "/v1/shipments";
+
+    // URL .../shipments und Method POST
+    public ResponseEntity<?> createShipment(@RequestBody ShipmentResource shipment) {
+        // call boundary service
+        HttpHeaders httpHeaders = new HttpHeaders();
+        // we need to use the header later as well
+        ShipmentListResource resource = new ShipmentListResource();
+        return new ResponseEntity<>(resource, httpHeaders, HttpStatus.CREATED);
+    }
+
+    // URL .../shipments und Method GET
+    public ShipmentListResource findAllShipments() {
+        // call boundary service
+        return new ShipmentListResource();
+    }
+}

--- a/backend/src/main/java/org/educama/shipment/api/resource/ShipmentListResource.java
+++ b/backend/src/main/java/org/educama/shipment/api/resource/ShipmentListResource.java
@@ -1,0 +1,19 @@
+/*
+ * *************************************************************************
+ *
+ * Copyright:       Robert Bosch GmbH, 2016
+ *
+ * *************************************************************************
+ */
+
+/**
+ * Dear "developer", please document your class RIGHT HERE!.
+ */
+
+package org.educama.shipment.api.resource;
+
+import java.util.List;
+
+public class ShipmentListResource {
+    public List<ShipmentResource> shipments;
+}

--- a/backend/src/main/java/org/educama/shipment/api/resource/ShipmentResource.java
+++ b/backend/src/main/java/org/educama/shipment/api/resource/ShipmentResource.java
@@ -1,0 +1,20 @@
+/*
+ * *************************************************************************
+ *
+ * Copyright:       Robert Bosch GmbH, 2016
+ *
+ * *************************************************************************
+ */
+
+/**
+ * Dear "developer", please document your class RIGHT HERE!.
+ */
+
+package org.educama.shipment.api.resource;
+
+public class ShipmentResource {
+
+    public long id;
+    public String senderAdress;
+    public String receiverAdress;
+}

--- a/backend/src/main/java/org/educama/shipment/boundary/ShipmentBoundaryService.java
+++ b/backend/src/main/java/org/educama/shipment/boundary/ShipmentBoundaryService.java
@@ -1,0 +1,19 @@
+/*
+ * *************************************************************************
+ *
+ * Copyright:       Robert Bosch GmbH, 2016
+ *
+ * *************************************************************************
+ */
+
+/**
+ * Dear "developer", please document your class RIGHT HERE!.
+ */
+
+package org.educama.shipment.boundary;
+
+import org.educama.shipment.model.Shipment;
+
+public interface ShipmentBoundaryService {
+    Shipment createShipment(Shipment shipment);
+}

--- a/backend/src/main/java/org/educama/shipment/boundary/impl/ShipmentBoundaryServiceImpl.java
+++ b/backend/src/main/java/org/educama/shipment/boundary/impl/ShipmentBoundaryServiceImpl.java
@@ -1,0 +1,31 @@
+/*
+ * *************************************************************************
+ *
+ * Copyright:       Robert Bosch GmbH, 2016
+ *
+ * *************************************************************************
+ */
+
+/**
+ * Dear "developer", please document your class RIGHT HERE!.
+ */
+
+package org.educama.shipment.boundary.impl;
+
+import org.educama.shipment.boundary.ShipmentBoundaryService;
+import org.educama.shipment.model.Shipment;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class ShipmentBoundaryServiceImpl implements ShipmentBoundaryService {
+
+    @Override
+    public Shipment createShipment(Shipment shipment) {
+        // call repository to create shipment entity
+
+        // call camunda api to create a case instance
+        return null;
+    }
+}

--- a/backend/src/main/java/org/educama/shipment/model/Shipment.java
+++ b/backend/src/main/java/org/educama/shipment/model/Shipment.java
@@ -1,0 +1,25 @@
+/*
+ * *************************************************************************
+ *
+ * Copyright:       Robert Bosch GmbH, 2016
+ *
+ * *************************************************************************
+ */
+
+/**
+ * Dear "developer", please document your class RIGHT HERE!.
+ */
+
+package org.educama.shipment.model;
+
+import org.springframework.data.jpa.domain.AbstractPersistable;
+
+import javax.persistence.Entity;
+
+@Entity
+public class Shipment extends AbstractPersistable<Long> {
+
+    public String senderAdress;
+    public String receiverAdress;
+
+}

--- a/backend/src/main/java/org/educama/shipment/repository/ShipmentRepository.java
+++ b/backend/src/main/java/org/educama/shipment/repository/ShipmentRepository.java
@@ -1,0 +1,19 @@
+/*
+ * *************************************************************************
+ *
+ * Copyright:       Robert Bosch GmbH, 2016
+ *
+ * *************************************************************************
+ */
+
+/**
+ * Dear "developer", please document your class RIGHT HERE!.
+ */
+
+package org.educama.shipment.repository;
+
+import org.educama.shipment.model.Shipment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ShipmentRepository extends JpaRepository<Shipment, Long> {
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,3 +1,6 @@
 server.port=8081
 # By default the starter registers a controller to redirect / to camundas bundled index.html
 camunda.bpm.webapp.index-redirect-enabled=false
+
+org.educama.configuration.adminUser = educama
+org.educama.configuration.adminPassword = educama

--- a/backend/src/test/resources/application.properties
+++ b/backend/src/test/resources/application.properties
@@ -2,3 +2,6 @@
 server.port=8091
 # By default the starter registers a controller to redirect / to camundas bundled index.html
 camunda.bpm.webapp.index-redirect-enabled=false
+
+org.educama.configuration.adminUser = educama
+org.educama.configuration.adminPassword = educama


### PR DESCRIPTION
During dev-stage it may be helpful to have a configured educama-demo-user in Camunda-config. By extending SpringBootProcessApplication the configuration via ProcessEnginePlugin will be possible. It seems that the name 'ProcessEngine' is correct, also if we use de CMMN-Engine. Further research to the CMMN-Engine will come up with other issues in the backend.