### PR TITLE
ECM-45: Create Camunda-demo-user in backend

### DIFF
--- a/backend/src/main/java/org/educama/configuration/DefaultUserConfiguration.java
+++ b/backend/src/main/java/org/educama/configuration/DefaultUserConfiguration.java
@@ -1,0 +1,95 @@
+package org.educama.configuration;
+
+import javax.annotation.PostConstruct;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import org.camunda.bpm.engine.authorization.Authorization;
+import org.camunda.bpm.engine.authorization.Resources;
+import org.camunda.bpm.engine.AuthorizationService;
+import org.camunda.bpm.engine.IdentityService;
+import org.camunda.bpm.engine.identity.Group;
+import org.camunda.bpm.engine.task.TaskQuery;
+import org.camunda.bpm.engine.FilterService;
+import org.camunda.bpm.engine.filter.Filter;
+import org.camunda.bpm.engine.identity.User;
+import org.camunda.bpm.engine.TaskService;
+
+@Component
+public class DefaultUserConfiguration {
+
+    @Autowired
+    IdentityService identityService;
+
+    @Autowired
+    AuthorizationService authorizationService;
+
+    @Autowired
+    TaskService taskService;
+
+    @Autowired
+    FilterService filterService;
+
+
+    @Value("${org.educama.configuration.adminUser}")
+    private String adminUsername;
+
+    @Value("${org.educama.configuration.adminPassword}")
+    private String adminPassword;
+
+
+    @PostConstruct
+    protected void init() {
+        if(userExists(adminUsername))
+            return;
+
+        User user = createDefaultUser(adminUsername, adminPassword);
+        Group adminGroup = createAdminGroup(user);
+        grantAuthorizationWithPermissions(adminGroup);
+        createAssignedTaskQuery();
+    }
+
+    private boolean userExists(String username) {
+        return (identityService.createUserQuery().userId(username).count() > 0);
+    }
+
+    private User createDefaultUser(String username, String password) {
+        User user = identityService.newUser(username);
+        user.setPassword(password);
+        user.setFirstName("EduCaMa");
+        user.setLastName("User");
+        identityService.saveUser(user);
+
+        return user;
+    }
+
+    private Group createAdminGroup(User user) {
+        Group adminGroup = identityService.newGroup("camunda-admin");
+        identityService.saveGroup(adminGroup);
+        identityService.createMembership(user.getId(), adminGroup.getId());
+
+        return adminGroup;
+    }
+
+    private void grantAuthorizationWithPermissions(Group adminGroup) {
+        Authorization authorization = authorizationService.createNewAuthorization(Authorization.AUTH_TYPE_GRANT);
+        authorization.setGroupId(adminGroup.getId());
+        authorization.setResource(Resources.USER);
+        authorization.addPermission(org.camunda.bpm.engine.authorization.Permissions.ALL);
+        authorizationService.saveAuthorization(authorization);
+    }
+
+    /**
+     * creates a task query to select task to the logged in user.
+     * Otherwise you would have to manually create a filter in TaskList after each boot up
+     */
+    private void createAssignedTaskQuery() {
+        TaskQuery query = taskService.createTaskQuery().taskAssignee(adminUsername);
+        Filter taskFilter = filterService.newTaskFilter("assigned Tasks");
+        taskFilter.setOwner(adminUsername);
+        taskFilter.setQuery(query);
+        filterService.saveFilter(taskFilter);
+    }
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,3 +1,6 @@
 server.port=8081
 # By default the starter registers a controller to redirect / to camundas bundled index.html
 camunda.bpm.webapp.index-redirect-enabled=false
+
+org.educama.configuration.adminUser = educama
+org.educama.configuration.adminPassword = educama

--- a/backend/src/test/resources/application.properties
+++ b/backend/src/test/resources/application.properties
@@ -2,3 +2,6 @@
 server.port=8091
 # By default the starter registers a controller to redirect / to camundas bundled index.html
 camunda.bpm.webapp.index-redirect-enabled=false
+
+org.educama.configuration.adminUser = educama
+org.educama.configuration.adminPassword = educama


### PR DESCRIPTION
During dev-stage it may be helpful to have a configured educama-demo-user in Camunda-config. By extending SpringBootProcessApplication the configuration via ProcessEnginePlugin will be possible. It seems that the name 'ProcessEngine' is correct, also if we use de CMMN-Engine. Further research to the CMMN-Engine will come up with other issues in the backend.