### PR TITLE
ECM-73: TabView for Shipmentlist and Tasklist created

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -3,7 +3,7 @@ import {Routes, RouterModule} from '@angular/router';
 const routes: Routes = [
     {
         path: '',
-        redirectTo: '/shipments',
+        redirectTo: '/home',
         pathMatch: 'full'
     }
 ];

--- a/frontend/src/app/common/ui/ui.module.ts
+++ b/frontend/src/app/common/ui/ui.module.ts
@@ -7,13 +7,14 @@ import {
     DropdownModule,
     InputTextModule,
     InputTextareaModule,
-    PanelModule
+    PanelModule,
+    TabViewModule
 } from 'primeng/primeng';
 
 @NgModule({
     imports: [CommonModule],
     exports: [ButtonModule, DataTableModule, DialogModule, DropdownModule,
-        InputTextModule, InputTextareaModule, PanelModule]
+        InputTextModule, InputTextareaModule, PanelModule, TabViewModule]
 })
 export class UIModule {
     static forRoot(): ModuleWithProviders {

--- a/frontend/src/app/shipment/container/shipment-capture-page.component.ts
+++ b/frontend/src/app/shipment/container/shipment-capture-page.component.ts
@@ -31,7 +31,7 @@ export class ShipmentCapturePageComponent {
         shipment.senderAddress = createShipmentEvent.senderAddress;
         this._shipmentService.createShipment(shipment)
             .subscribe(shipment => {
-                this._router.navigate(['/shipments']);
+                this._router.navigate(['/home']);
             })
     }
 
@@ -39,7 +39,7 @@ export class ShipmentCapturePageComponent {
      * Handles the cancellation of a new shipment creation
      */
     public onCreateShipmentCancellationEvent() {
-        this._router.navigate(['/shipments']);
+        this._router.navigate(['/home']);
     }
 
     /*

--- a/frontend/src/app/shipment/container/tabview-page.component.html
+++ b/frontend/src/app/shipment/container/tabview-page.component.html
@@ -1,0 +1,10 @@
+<div>
+    <p-tabView>
+        <p-tabPanel header="Shipmentlist">
+            <educama-shipment-list-page></educama-shipment-list-page>
+        </p-tabPanel>
+        <p-tabPanel header="Tasklist">
+            Tasklist WIP
+        </p-tabPanel>
+    </p-tabView>
+</div>

--- a/frontend/src/app/shipment/container/tabview-page.component.ts
+++ b/frontend/src/app/shipment/container/tabview-page.component.ts
@@ -1,0 +1,10 @@
+import {Component, OnInit} from '@angular/core';
+import {TabViewModule} from 'primeng/primeng';
+
+@Component({
+    selector: 'educama-tabview-page',
+    templateUrl: `./tabview-page.component.html`
+})
+export class TabViewComponent{
+
+}

--- a/frontend/src/app/shipment/routes/shipment.routes.ts
+++ b/frontend/src/app/shipment/routes/shipment.routes.ts
@@ -2,6 +2,7 @@ import {Routes, RouterModule} from "@angular/router";
 import {ShipmentListPageComponent} from "../container/shipment-list-page.component";
 import {ShipmentCaptureComponent} from "../components/shipment-capture.component";
 import {ShipmentCapturePageComponent} from "../container/shipment-capture-page.component";
+import {TabViewComponent} from "../container/tabview-page.component";
 
 /*
  * Router configuration for the component task
@@ -14,6 +15,10 @@ const SHIPMENT_ROUTES: Routes = [
     {
         path: 'shipments/capture',
         component: ShipmentCapturePageComponent
+    },
+    {
+        path: 'home',
+        component: TabViewComponent
     },
 ];
 

--- a/frontend/src/app/shipment/shipment.module.ts
+++ b/frontend/src/app/shipment/shipment.module.ts
@@ -6,11 +6,12 @@ import {ShipmentListPageComponent} from "./container/shipment-list-page.componen
 import {ShipmentListComponent} from "./components/shipment-list.component";
 import {ShipmentCapturePageComponent} from "./container/shipment-capture-page.component";
 import {ShipmentCaptureComponent} from "./components/shipment-capture.component";
+import {TabViewComponent} from "./container/tabview-page.component";
 
 @NgModule({
     imports: [SharedModule, SHIPMENT_ROUTING],
     declarations: [ShipmentCapturePageComponent, ShipmentCaptureComponent,
-        ShipmentListPageComponent, ShipmentListComponent],
+        ShipmentListPageComponent, ShipmentListComponent, TabViewComponent],
     exports: [ShipmentListPageComponent, ShipmentCapturePageComponent],
     providers: [ShipmentService]
 })


### PR DESCRIPTION
Wir haben folgende Probleme entdeckt und würden uns über Feedback freuen:

- Der Microsoft Edge Browser lädt die Shipments nicht nach und zeigt neu angelegte Shipments nicht an. Öffnet man den localhost:8080 in bspw. Firefox, so werden alle Shipments angezeigt die in Edge erstellt wurden.

- Wenn die Liste genügend Einträge hat, sodass man scrollen muss, so überlappen die TabView-Komponenten die div-box des Educama-Headers. Wir vermuten ein css-Problem von PrimeNG, aber konnten dies noch nicht lösen 