### PR TITLE
changed checkstyle lineSeperator to lf_cr_crlf

### DIFF
--- a/backend/checkstyle.xml
+++ b/backend/checkstyle.xml
@@ -21,7 +21,9 @@
 <module name="Checker">
     <!-- Checks whether files end with a new line.                        -->
     <!-- See http://checkstyle.sf.net/config_misc.html#NewlineAtEndOfFile -->
-    <module name="NewlineAtEndOfFile"/>
+    <module name="NewlineAtEndOfFile">
+		<property name="lineSeparator" value="lf_cr_crlf"/>
+	</module>
 
     <!-- Checks that property files contain the same keys.         -->
     <!-- See http://checkstyle.sf.net/config_misc.html#Translation -->


### PR DESCRIPTION
Der lineSeperator wurde auf lf_cr_crlf umgestellt, da er beim starten bei einigen Systemen einen Fehler angezeigt hat, dies sollte nun behoben sein. 