### PR TITLE
EEM-272: Fixing errors in Live-System concerning dateformat types

### DIFF
--- a/backend/src/main/java/org/educama/shipment/api/datastructure/FlightDS.java
+++ b/backend/src/main/java/org/educama/shipment/api/datastructure/FlightDS.java
@@ -24,8 +24,8 @@ public class FlightDS {
         this.airline = flight.airline;
         this.departureAirport = flight.departureAirport;
         this.destinationAirport = flight.destinationAirport;
-        this.departureTime = flight.departureTime.toString();
-        this.destinationTime = flight.destinationTime.toString();
+        this.departureTime = flight.departureTime == null ? null : flight.departureTime.toString();
+        this.destinationTime = flight.destinationTime == null ? null : flight.destinationTime.toString();
         this.price = flight.price;
     }
 

--- a/backend/src/main/java/org/educama/shipment/model/Flight.java
+++ b/backend/src/main/java/org/educama/shipment/model/Flight.java
@@ -33,8 +33,8 @@ public class Flight {
         this.airline = airline;
         this.departureAirport = departureAirport;
         this.destinationAirport = destinationAirport;
-        this.departureTime = Instant.parse(departureTime);
-        this.destinationTime = Instant.parse(destinationTime);
+        this.departureTime = departureTime == null ? null : Instant.parse(departureTime);
+        this.destinationTime = destinationTime == null ? null : Instant.parse(destinationTime);
         this.price = price;
     }
 }

--- a/backend/src/main/java/org/educama/shipment/model/InstantConverter.java
+++ b/backend/src/main/java/org/educama/shipment/model/InstantConverter.java
@@ -11,11 +11,11 @@ public class InstantConverter implements AttributeConverter<Instant, Timestamp> 
 
     @Override
     public Timestamp convertToDatabaseColumn(Instant instant) {
-        return Timestamp.from(instant);
+        return instant == null ? null : Timestamp.from(instant);
     }
 
     @Override
     public Instant convertToEntityAttribute(Timestamp timestamp) {
-        return timestamp.toInstant();
+        return timestamp == null ? null : timestamp.toInstant();
     }
 }

--- a/backend/src/main/resources/db/migration/common/V01_009__change_date_datatypes.sql
+++ b/backend/src/main/resources/db/migration/common/V01_009__change_date_datatypes.sql
@@ -1,0 +1,5 @@
+ALTER TABLE shipment DROP COLUMN departure_time;
+ALTER TABLE shipment DROP COLUMN destination_time;
+
+ALTER TABLE shipment ADD COLUMN departure_time TIMESTAMP null;
+ALTER TABLE shipment ADD COLUMN destination_time TIMESTAMP null;

--- a/backend/src/main/resources/db/migration/common/V01_010__change_date_datatypes.sql
+++ b/backend/src/main/resources/db/migration/common/V01_010__change_date_datatypes.sql
@@ -1,2 +1,0 @@
-alter table shipment modify departure_time TIMESTAMP null;
-alter table shipment modify destination_time TIMESTAMP null;


### PR DESCRIPTION
Der Converter wurde so verändert das er mit null-Werten aus der Datenbank umgehen kann.
Die Spalten die departure_time und destination_time werden jetzt zuerst gelöscht und neu erstellt um nicht "trivial" konvertierbare Einträge zu löschen.